### PR TITLE
Revert leaf removals if they delete all leaves

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open("README.md") as readme_file:
 requirements = [
     "Click>=7.0,<8",
     "python-igraph>=0.8.0,<1",
-    "wostools>=2.0.6,<3",
+    "wostools>=2.0.7,<3",
 ]
 
 setup_requirements = [

--- a/src/sap/cli.py
+++ b/src/sap/cli.py
@@ -90,7 +90,7 @@ def describe(ctx, sources, output):
             click.echo(graph.summary() + "\n")
         except TypeError:
             logger.exception(
-                f"There was an error processin the graph\n{graph.summary()}"
+                f"There was an error processing the graph\n{graph.summary()}"
             )
 
 


### PR DESCRIPTION
The minimal tree we consider is (leaf) -> (trunk) -> (root), this violates some of the leaf definition rules, like requiring 3 different paths to the root.

So this PR makes it so the exclusion rules remove all the leafs, then we revert the exclusion rules.
